### PR TITLE
Added GetSongsByLimit for pagination

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -211,8 +211,8 @@
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| token | [string](#string) | optional |  |
-| limit | [int32](#int32) | optional |  |
+| page_token | [int64](#int64) | optional |  |
+| page_size | [int64](#int64) | optional |  |
 
 
 
@@ -228,7 +228,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
-| token | [string](#string) |  |  |
+| next_page_token | [int64](#int64) |  |  |
 
 
 
@@ -244,8 +244,8 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | ids | [string](#string) | repeated |  |
-| token | [string](#string) | optional |  |
-| limit | [int32](#int32) | optional |  |
+| page_token | [int64](#int64) | optional |  |
+| page_size | [int64](#int64) | optional |  |
 
 
 
@@ -261,7 +261,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
-| token | [string](#string) |  |  |
+| next_page_token | [int64](#int64) |  |  |
 
 
 
@@ -280,8 +280,8 @@
 
 Using an * for the value will return any song with that tag set. Using a specific value for the tag will return only songs with that exact combination of Key/Value |
 | filter | [Filter](#tensorbeat.datalake.Filter) |  |  |
-| token | [string](#string) | optional |  |
-| limit | [int32](#int32) | optional |  |
+| page_token | [int64](#int64) | optional |  |
+| page_size | [int64](#int64) | optional |  |
 
 
 
@@ -313,7 +313,7 @@ Using an * for the value will return any song with that tag set. Using a specifi
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
-| token | [string](#string) |  |  |
+| next_page_token | [int64](#int64) |  |  |
 
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -209,6 +209,12 @@
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) | optional |  |
+| limit | [int32](#int32) | optional |  |
+
+
 
 
 
@@ -222,6 +228,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
+| token | [string](#string) |  |  |
 
 
 
@@ -237,6 +244,8 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | ids | [string](#string) | repeated |  |
+| token | [string](#string) | optional |  |
+| limit | [int32](#int32) | optional |  |
 
 
 
@@ -252,6 +261,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
+| token | [string](#string) |  |  |
 
 
 
@@ -270,6 +280,8 @@
 
 Using an * for the value will return any song with that tag set. Using a specific value for the tag will return only songs with that exact combination of Key/Value |
 | filter | [Filter](#tensorbeat.datalake.Filter) |  |  |
+| token | [string](#string) | optional |  |
+| limit | [int32](#int32) | optional |  |
 
 
 
@@ -301,6 +313,7 @@ Using an * for the value will return any song with that tag set. Using a specifi
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | songs | [tensorbeat.common.File](#tensorbeat.common.File) | repeated |  |
+| token | [string](#string) |  |  |
 
 
 

--- a/tensorbeat/datalake.proto
+++ b/tensorbeat/datalake.proto
@@ -13,16 +13,6 @@ enum Filter {
     NONE = 2;
 }
 
-message GetSongsByLimitRequest {
-    string token = 1;
-    string limit = 2;
-}
-
-message GetSongsByLimitResponse {
-    repeated tensorbeat.common.File songs = 1;
-    string token = 2;
-}
-
 message GetSongsByTagsRequest {
     
     /*
@@ -43,11 +33,14 @@ message GetSongsByTagsRequest {
     */
     map<string, string> tags = 1;
     Filter filter = 2;
+    optional string token = 3;
+    optional int32 limit = 4;
 
 }
 
 message GetSongsByTagsResponse {
     repeated tensorbeat.common.File songs = 1;
+    string token = 2;
 }
 
 message AddSongsRequest {
@@ -76,21 +69,27 @@ message RemoveTagsResponse {
     bool successful = 1;
 }
 
-message GetAllSongsRequest {}
+message GetAllSongsRequest {
+    optional string token = 1;
+    optional int32 limit = 2;
+}
 message GetAllSongsResponse {
     repeated tensorbeat.common.File songs = 1;
+    string token = 2;
 }
 
 message GetSongsByIDsRequest {
     repeated string ids = 1;
+    optional string token = 2;
+    optional int32 limit = 3;
 }
 message GetSongsByIDsResponse {
     repeated tensorbeat.common.File songs = 1;
+    string token = 2;
 }
 
 service DatalakeService {
     rpc GetAllSongs(GetAllSongsRequest) returns (GetAllSongsResponse);
-    rpc GetSongsByLimit(GetSongsByLimitRequest) returns (GetSongsByLimitResponse);
     rpc GetSongsByIDs(GetSongsByIDsRequest) returns (GetSongsByIDsResponse);
 
     rpc GetSongsByTags(GetSongsByTagsRequest) returns (GetSongsByTagsResponse);

--- a/tensorbeat/datalake.proto
+++ b/tensorbeat/datalake.proto
@@ -13,6 +13,16 @@ enum Filter {
     NONE = 2;
 }
 
+message GetSongsByLimitRequest {
+    string token = 1;
+    string limit = 2;
+}
+
+message GetSongsByLimitResponse {
+    repeated tensorbeat.common.File songs = 1;
+    string token = 2;
+}
+
 message GetSongsByTagsRequest {
     
     /*
@@ -80,6 +90,7 @@ message GetSongsByIDsResponse {
 
 service DatalakeService {
     rpc GetAllSongs(GetAllSongsRequest) returns (GetAllSongsResponse);
+    rpc GetSongsByLimit(GetSongsByLimitRequest) returns (GetSongsByLimitResponse);
     rpc GetSongsByIDs(GetSongsByIDsRequest) returns (GetSongsByIDsResponse);
 
     rpc GetSongsByTags(GetSongsByTagsRequest) returns (GetSongsByTagsResponse);

--- a/tensorbeat/datalake.proto
+++ b/tensorbeat/datalake.proto
@@ -33,14 +33,14 @@ message GetSongsByTagsRequest {
     */
     map<string, string> tags = 1;
     Filter filter = 2;
-    optional int64 pageToken = 3;
-    optional int64 pageSize = 4;
+    optional int64 page_token = 3;
+    optional int64 page_size = 4;
 
 }
 
 message GetSongsByTagsResponse {
     repeated tensorbeat.common.File songs = 1;
-    int64 nextToken = 2;
+    int64 next_page_token = 2;
 }
 
 message AddSongsRequest {
@@ -70,22 +70,22 @@ message RemoveTagsResponse {
 }
 
 message GetAllSongsRequest {
-    optional int64 pageToken = 1;
-    optional int64 pageSize = 2;
+    optional int64 page_token = 1;
+    optional int64 page_size = 2;
 }
 message GetAllSongsResponse {
     repeated tensorbeat.common.File songs = 1;
-    int64 nextToken = 2;
+    int64 next_page_token = 2;
 }
 
 message GetSongsByIDsRequest {
     repeated string ids = 1;
-    optional int64 pageToken = 2;
-    optional int64 pageSize = 3;
+    optional int64 page_token = 2;
+    optional int64 page_size = 3;
 }
 message GetSongsByIDsResponse {
     repeated tensorbeat.common.File songs = 1;
-    int64 nextToken = 2;
+    int64 next_page_token = 2;
 }
 
 service DatalakeService {

--- a/tensorbeat/datalake.proto
+++ b/tensorbeat/datalake.proto
@@ -33,14 +33,14 @@ message GetSongsByTagsRequest {
     */
     map<string, string> tags = 1;
     Filter filter = 2;
-    optional string token = 3;
-    optional int32 limit = 4;
+    optional int64 pageToken = 3;
+    optional int64 pageSize = 4;
 
 }
 
 message GetSongsByTagsResponse {
     repeated tensorbeat.common.File songs = 1;
-    string token = 2;
+    int64 nextToken = 2;
 }
 
 message AddSongsRequest {
@@ -70,22 +70,22 @@ message RemoveTagsResponse {
 }
 
 message GetAllSongsRequest {
-    optional string token = 1;
-    optional int32 limit = 2;
+    optional int64 pageToken = 1;
+    optional int64 pageSize = 2;
 }
 message GetAllSongsResponse {
     repeated tensorbeat.common.File songs = 1;
-    string token = 2;
+    int64 nextToken = 2;
 }
 
 message GetSongsByIDsRequest {
     repeated string ids = 1;
-    optional string token = 2;
-    optional int32 limit = 3;
+    optional int64 pageToken = 2;
+    optional int64 pageSize = 3;
 }
 message GetSongsByIDsResponse {
     repeated tensorbeat.common.File songs = 1;
-    string token = 2;
+    int64 nextToken = 2;
 }
 
 service DatalakeService {


### PR DESCRIPTION
Added `GetSongsByLimit` which takes a `GetSongsByLimitRequest` and returns a `GetSongsByLimitResponse`.

`GetSongsByLimitRequest` takes a token for the starting song and a limit for the total amount of songs. `GetSongsByLimitResponse` returns a list of songs and the next token.